### PR TITLE
Add CLAUDE.md with git workflow instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code instructions
+
+## Git workflow
+
+- Never commit or push directly to `master`.
+- All changes must go through a feature branch and a pull request.
+- Branch names should be short and descriptive (e.g. `add-matrix-post`, `fix-math-rendering`).


### PR DESCRIPTION
Instructs Claude Code to always use feature branches and PRs — never commit directly to master.