### PR TITLE
Fix setup-uv tag: use v8.1.0 instead of v8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
       - name: Build site
         run: uv run pelican content -o output -s publishconf.py
       - uses: actions/configure-pages@v6


### PR DESCRIPTION
Unlike the `actions/*` repos, `astral-sh/setup-uv` doesn't publish a floating major version tag (`v8`). The correct tag is the full semver `v8.1.0`.