### PR TITLE
Update master references to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,6 @@
 
 ## Git workflow
 
-- Never commit or push directly to `master`.
+- Never commit or push directly to `main`.
 - All changes must go through a feature branch and a pull request.
 - Branch names should be short and descriptive (e.g. `add-matrix-post`, `fix-math-rendering`).


### PR DESCRIPTION
Updates the workflow trigger branch and CLAUDE.md to use `main` following the default branch rename.