### PR TITLE
Fix deploy workflow to trigger on main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Changes the deploy workflow trigger from `master` to `main` to match the renamed default branch

## Test plan
- [ ] Merge and verify the deploy workflow runs successfully on push to `main`