### PR TITLE
Update Brightway header link to docs.brightway.dev

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,7 +15,7 @@ PATH = 'content'
 LINKS = (
     ('Notable posts', 'https://chris.mutel.org/tag/notable/index.html'),
     ('DdS', 'https://www.d-d-s.ch/'),
-    ('Brightway', 'https://brightwaylca.org'),
+    ('Brightway', 'https://docs.brightway.dev'),
     ('Cauldron', 'https://cauldron.ch/'),
     ('Papers', 'http://scholar.google.ch/citations?user=SJiuf-MAAAAJ'),
 )


### PR DESCRIPTION
Closes #1

Updates the Brightway link in the site header from `brightwaylca.org` to `docs.brightway.dev`.